### PR TITLE
FIx Issue with Whoogle and This

### DIFF
--- a/src/catppuccin-vimium-base.css
+++ b/src/catppuccin-vimium-base.css
@@ -7,7 +7,7 @@
 }
 
 #vimiumHintMarkerContainer div span {
-  color: var(--mantle);
+  color: var(--mantle) !important;
   text-shadow: none;
 }
 


### PR DESCRIPTION
Not sure if the fix should be applied here, but I noticed that it was really hard to read the hints that pop up. What to select to click the link.

It seems this theme's span setting gets overwritten by my whoogle theme also using catppuccin. So here is the fix I applied. Again not sure if this a hack let me know, thought I'd share with the community.

Before:

![image](https://github.com/catppuccin/vimium/assets/998807/d408a11a-58ec-465c-97eb-a107efac47e7)

After:

![image](https://github.com/catppuccin/vimium/assets/998807/2ddcd7a3-9f3c-4040-b534-1c428b421504)

