### PR TITLE
fix: leaky global vars

### DIFF
--- a/dist/catppuccin-vimium-frappe.css
+++ b/dist/catppuccin-vimium-frappe.css
@@ -1,27 +1,27 @@
 /* Frappe palette */
 
 :root {
-  --rosewater: #f2d5cf;
-  --peach: #ef9f76;
-  --blue: #8caaee;
-  --lavender: #babbf1;
-  --green: #a6d189;
-  --text: #c6d0f5;
-  --surface2: #626880;
-  --surface0: #414559;
-  --base: #303446;
-  --mantle: #292c3c;
+  --vimium-rosewater: #f2d5cf;
+  --vimium-peach: #ef9f76;
+  --vimium-blue: #8caaee;
+  --vimium-lavender: #babbf1;
+  --vimium-green: #a6d189;
+  --vimium-text: #c6d0f5;
+  --vimium-surface2: #626880;
+  --vimium-surface0: #414559;
+  --vimium-base: #303446;
+  --vimium-mantle: #292c3c;
 }
 #vimiumHintMarkerContainer div.internalVimiumHintMarker, #vimiumHintMarkerContainer div.vimiumHintMarker {
   padding: 3px 4px;
-  background: var(--peach);
+  background: var(--vimium-peach);
   border: 1;
-  border-color: var(--mantle);
+  border-color: var(--vimium-mantle);
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
 }
 
 #vimiumHintMarkerContainer div span {
-  color: var(--mantle);
+  color: var(--vimium-mantle);
   text-shadow: none;
 }
 
@@ -30,12 +30,12 @@
 }
 
 #vimiumHintMarkerContainer div > .matchingCharacter ~ span {
-  color: var(--surface2);
+  color: var(--vimium-surface2);
 }
 
 #vomnibar {
-  background: var(--base);
-  border: 2px solid var(--lavender);
+  background: var(--vimium-base);
+  border: 2px solid var(--vimium-lavender);
   animation: show 200ms cubic-bezier(0, 0, 0.2, 1) forwards;
   max-height: calc(100vh - 70px);
   overflow: hidden;
@@ -53,8 +53,8 @@
 }
 
 #vomnibar input {
-  color: var(--text);
-  background: var(--base);
+  color: var(--vimium-text);
+  background: var(--vimium-base);
   border: none;
   height: unset;
   padding: 16px 30px;
@@ -63,19 +63,19 @@
 #vomnibar .vomnibarSearchArea {
   border: none;
   padding: unset;
-  background: var(--base)
+  background: var(--vimium-base)
 }
 
 #vomnibar ul {
   padding: 0;
   margin: 0;
-  background: var(--base);
-  border-top: 1px solid var(--surface0);
+  background: var(--vimium-base);
+  border-top: 1px solid var(--vimium-surface0);
 }
 
 #vomnibar li {
   padding: 10px;
-  border-bottom: 1px solid var(--surface0)
+  border-bottom: 1px solid var(--vimium-surface0)
 }
 
 #vomnibar li .vomnibarTopHalf,
@@ -84,48 +84,48 @@
 }
 
 #vomnibar li .vomnibarSource {
-  color: var(--peach);
+  color: var(--vimium-peach);
 }
 
 #vomnibar li em,
 #vomnibar li .vomnibarTitle {
-  color: var(--blue);
+  color: var(--vimium-blue);
   font-weight: bold;
 }
 
 #vomnibar li .vomnibarUrl {
-  color: var(--rosewater);
+  color: var(--vimium-rosewater);
 }
 
 #vomnibar li .vomnibarMatch {
-  color: var(--green);
+  color: var(--vimium-green);
   font-weight: bold;
 }
 
 #vomnibar li .vomnibarTitle .vomnibarMatch {
-  color: var(--blue);
+  color: var(--vimium-blue);
 }
 
 #vomnibar li.vomnibarSelected {
-  background-color: var(--surface0);
+  background-color: var(--vimium-surface0);
 }
 
 div.vimiumHUD {
-  background: var(--base);
+  background: var(--vimium-base);
   border: none;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
 }
 
 div.vimiumHUD span#hud-find-input,
 div.vimiumHUD .vimiumHUDSearchAreaInner {
-  color: var(--text)
+  color: var(--vimium-text)
 }
 
 div.vimiumHUD .hud-find {
-  background-color: var(--base);
+  background-color: var(--vimium-base);
   border: none;
 }
 
 div.vimiumHUD .vimiumHUDSearchArea {
-  background-color: var(--base);
+  background-color: var(--vimium-base);
 }

--- a/dist/catppuccin-vimium-latte.css
+++ b/dist/catppuccin-vimium-latte.css
@@ -1,27 +1,27 @@
 /* Latte palette */
 
 :root {
-  --rosewater: #dc8a78;
-  --peach: #fe640b;
-  --green: #40a02b;
-  --blue: #1e66f5;
-  --lavender: #7287fd;
-  --text: #4c4f69;
-  --surface2: #acb0be;
-  --surface0: #ccd0da;
-  --base: #eff1f5;
-  --mantle: #e6e9ef;
+  --vimium-rosewater: #dc8a78;
+  --vimium-peach: #fe640b;
+  --vimium-green: #40a02b;
+  --vimium-blue: #1e66f5;
+  --vimium-lavender: #7287fd;
+  --vimium-text: #4c4f69;
+  --vimium-surface2: #acb0be;
+  --vimium-surface0: #ccd0da;
+  --vimium-base: #eff1f5;
+  --vimium-mantle: #e6e9ef;
 }
 #vimiumHintMarkerContainer div.internalVimiumHintMarker, #vimiumHintMarkerContainer div.vimiumHintMarker {
   padding: 3px 4px;
-  background: var(--peach);
+  background: var(--vimium-peach);
   border: 1;
-  border-color: var(--mantle);
+  border-color: var(--vimium-mantle);
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
 }
 
 #vimiumHintMarkerContainer div span {
-  color: var(--mantle);
+  color: var(--vimium-mantle);
   text-shadow: none;
 }
 
@@ -30,12 +30,12 @@
 }
 
 #vimiumHintMarkerContainer div > .matchingCharacter ~ span {
-  color: var(--surface2);
+  color: var(--vimium-surface2);
 }
 
 #vomnibar {
-  background: var(--base);
-  border: 2px solid var(--lavender);
+  background: var(--vimium-base);
+  border: 2px solid var(--vimium-lavender);
   animation: show 200ms cubic-bezier(0, 0, 0.2, 1) forwards;
   max-height: calc(100vh - 70px);
   overflow: hidden;
@@ -53,8 +53,8 @@
 }
 
 #vomnibar input {
-  color: var(--text);
-  background: var(--base);
+  color: var(--vimium-text);
+  background: var(--vimium-base);
   border: none;
   height: unset;
   padding: 16px 30px;
@@ -63,19 +63,19 @@
 #vomnibar .vomnibarSearchArea {
   border: none;
   padding: unset;
-  background: var(--base)
+  background: var(--vimium-base)
 }
 
 #vomnibar ul {
   padding: 0;
   margin: 0;
-  background: var(--base);
-  border-top: 1px solid var(--surface0);
+  background: var(--vimium-base);
+  border-top: 1px solid var(--vimium-surface0);
 }
 
 #vomnibar li {
   padding: 10px;
-  border-bottom: 1px solid var(--surface0)
+  border-bottom: 1px solid var(--vimium-surface0)
 }
 
 #vomnibar li .vomnibarTopHalf,
@@ -84,48 +84,48 @@
 }
 
 #vomnibar li .vomnibarSource {
-  color: var(--peach);
+  color: var(--vimium-peach);
 }
 
 #vomnibar li em,
 #vomnibar li .vomnibarTitle {
-  color: var(--blue);
+  color: var(--vimium-blue);
   font-weight: bold;
 }
 
 #vomnibar li .vomnibarUrl {
-  color: var(--rosewater);
+  color: var(--vimium-rosewater);
 }
 
 #vomnibar li .vomnibarMatch {
-  color: var(--green);
+  color: var(--vimium-green);
   font-weight: bold;
 }
 
 #vomnibar li .vomnibarTitle .vomnibarMatch {
-  color: var(--blue);
+  color: var(--vimium-blue);
 }
 
 #vomnibar li.vomnibarSelected {
-  background-color: var(--surface0);
+  background-color: var(--vimium-surface0);
 }
 
 div.vimiumHUD {
-  background: var(--base);
+  background: var(--vimium-base);
   border: none;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
 }
 
 div.vimiumHUD span#hud-find-input,
 div.vimiumHUD .vimiumHUDSearchAreaInner {
-  color: var(--text)
+  color: var(--vimium-text)
 }
 
 div.vimiumHUD .hud-find {
-  background-color: var(--base);
+  background-color: var(--vimium-base);
   border: none;
 }
 
 div.vimiumHUD .vimiumHUDSearchArea {
-  background-color: var(--base);
+  background-color: var(--vimium-base);
 }

--- a/dist/catppuccin-vimium-macchiato.css
+++ b/dist/catppuccin-vimium-macchiato.css
@@ -1,27 +1,27 @@
 /* Macchiato palette */
 
 :root {
-  --rosewater: #f4dbd6;
-  --peach: #f5a97f;
-  --green: #a6da95;
-  --blue: #8aadf4;
-  --lavender: #b7bdf8;
-  --text: #cad3f5;
-  --surface2: #5b6078;
-  --surface0: #363a4f;
-  --base: #24273a;
-  --mantle: #1e2030;
+  --vimium-rosewater: #f4dbd6;
+  --vimium-peach: #f5a97f;
+  --vimium-green: #a6da95;
+  --vimium-blue: #8aadf4;
+  --vimium-lavender: #b7bdf8;
+  --vimium-text: #cad3f5;
+  --vimium-surface2: #5b6078;
+  --vimium-surface0: #363a4f;
+  --vimium-base: #24273a;
+  --vimium-mantle: #1e2030;
 }
 #vimiumHintMarkerContainer div.internalVimiumHintMarker, #vimiumHintMarkerContainer div.vimiumHintMarker {
   padding: 3px 4px;
-  background: var(--peach);
+  background: var(--vimium-peach);
   border: 1;
-  border-color: var(--mantle);
+  border-color: var(--vimium-mantle);
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
 }
 
 #vimiumHintMarkerContainer div span {
-  color: var(--mantle);
+  color: var(--vimium-mantle);
   text-shadow: none;
 }
 
@@ -30,12 +30,12 @@
 }
 
 #vimiumHintMarkerContainer div > .matchingCharacter ~ span {
-  color: var(--surface2);
+  color: var(--vimium-surface2);
 }
 
 #vomnibar {
-  background: var(--base);
-  border: 2px solid var(--lavender);
+  background: var(--vimium-base);
+  border: 2px solid var(--vimium-lavender);
   animation: show 200ms cubic-bezier(0, 0, 0.2, 1) forwards;
   max-height: calc(100vh - 70px);
   overflow: hidden;
@@ -53,8 +53,8 @@
 }
 
 #vomnibar input {
-  color: var(--text);
-  background: var(--base);
+  color: var(--vimium-text);
+  background: var(--vimium-base);
   border: none;
   height: unset;
   padding: 16px 30px;
@@ -63,19 +63,19 @@
 #vomnibar .vomnibarSearchArea {
   border: none;
   padding: unset;
-  background: var(--base)
+  background: var(--vimium-base)
 }
 
 #vomnibar ul {
   padding: 0;
   margin: 0;
-  background: var(--base);
-  border-top: 1px solid var(--surface0);
+  background: var(--vimium-base);
+  border-top: 1px solid var(--vimium-surface0);
 }
 
 #vomnibar li {
   padding: 10px;
-  border-bottom: 1px solid var(--surface0)
+  border-bottom: 1px solid var(--vimium-surface0)
 }
 
 #vomnibar li .vomnibarTopHalf,
@@ -84,48 +84,48 @@
 }
 
 #vomnibar li .vomnibarSource {
-  color: var(--peach);
+  color: var(--vimium-peach);
 }
 
 #vomnibar li em,
 #vomnibar li .vomnibarTitle {
-  color: var(--blue);
+  color: var(--vimium-blue);
   font-weight: bold;
 }
 
 #vomnibar li .vomnibarUrl {
-  color: var(--rosewater);
+  color: var(--vimium-rosewater);
 }
 
 #vomnibar li .vomnibarMatch {
-  color: var(--green);
+  color: var(--vimium-green);
   font-weight: bold;
 }
 
 #vomnibar li .vomnibarTitle .vomnibarMatch {
-  color: var(--blue);
+  color: var(--vimium-blue);
 }
 
 #vomnibar li.vomnibarSelected {
-  background-color: var(--surface0);
+  background-color: var(--vimium-surface0);
 }
 
 div.vimiumHUD {
-  background: var(--base);
+  background: var(--vimium-base);
   border: none;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
 }
 
 div.vimiumHUD span#hud-find-input,
 div.vimiumHUD .vimiumHUDSearchAreaInner {
-  color: var(--text)
+  color: var(--vimium-text)
 }
 
 div.vimiumHUD .hud-find {
-  background-color: var(--base);
+  background-color: var(--vimium-base);
   border: none;
 }
 
 div.vimiumHUD .vimiumHUDSearchArea {
-  background-color: var(--base);
+  background-color: var(--vimium-base);
 }

--- a/dist/catppuccin-vimium-mocha.css
+++ b/dist/catppuccin-vimium-mocha.css
@@ -1,27 +1,27 @@
 /* Mocha palette */
 
 :root {
-  --rosewater: #f5e0dc;
-  --peach: #fab387;
-  --green: #a6e3a1;
-  --blue: #89b4fa;
-  --lavender: #b4befe;
-  --text: #cdd6f4;
-  --surface2: #585b70;
-  --surface0: #313244;
-  --base: #1e1e2e;
-  --mantle: #181825;
+  --vimium-rosewater: #f5e0dc;
+  --vimium-peach: #fab387;
+  --vimium-green: #a6e3a1;
+  --vimium-blue: #89b4fa;
+  --vimium-lavender: #b4befe;
+  --vimium-text: #cdd6f4;
+  --vimium-surface2: #585b70;
+  --vimium-surface0: #313244;
+  --vimium-base: #1e1e2e;
+  --vimium-mantle: #181825;
 }
 #vimiumHintMarkerContainer div.internalVimiumHintMarker, #vimiumHintMarkerContainer div.vimiumHintMarker {
   padding: 3px 4px;
-  background: var(--peach);
+  background: var(--vimium-peach);
   border: 1;
-  border-color: var(--mantle);
+  border-color: var(--vimium-mantle);
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
 }
 
 #vimiumHintMarkerContainer div span {
-  color: var(--mantle);
+  color: var(--vimium-mantle);
   text-shadow: none;
 }
 
@@ -30,12 +30,12 @@
 }
 
 #vimiumHintMarkerContainer div > .matchingCharacter ~ span {
-  color: var(--surface2);
+  color: var(--vimium-surface2);
 }
 
 #vomnibar {
-  background: var(--base);
-  border: 2px solid var(--lavender);
+  background: var(--vimium-base);
+  border: 2px solid var(--vimium-lavender);
   animation: show 200ms cubic-bezier(0, 0, 0.2, 1) forwards;
   max-height: calc(100vh - 70px);
   overflow: hidden;
@@ -53,8 +53,8 @@
 }
 
 #vomnibar input {
-  color: var(--text);
-  background: var(--base);
+  color: var(--vimium-text);
+  background: var(--vimium-base);
   border: none;
   height: unset;
   padding: 16px 30px;
@@ -63,19 +63,19 @@
 #vomnibar .vomnibarSearchArea {
   border: none;
   padding: unset;
-  background: var(--base)
+  background: var(--vimium-base)
 }
 
 #vomnibar ul {
   padding: 0;
   margin: 0;
-  background: var(--base);
-  border-top: 1px solid var(--surface0);
+  background: var(--vimium-base);
+  border-top: 1px solid var(--vimium-surface0);
 }
 
 #vomnibar li {
   padding: 10px;
-  border-bottom: 1px solid var(--surface0)
+  border-bottom: 1px solid var(--vimium-surface0)
 }
 
 #vomnibar li .vomnibarTopHalf,
@@ -84,48 +84,48 @@
 }
 
 #vomnibar li .vomnibarSource {
-  color: var(--peach);
+  color: var(--vimium-peach);
 }
 
 #vomnibar li em,
 #vomnibar li .vomnibarTitle {
-  color: var(--blue);
+  color: var(--vimium-blue);
   font-weight: bold;
 }
 
 #vomnibar li .vomnibarUrl {
-  color: var(--rosewater);
+  color: var(--vimium-rosewater);
 }
 
 #vomnibar li .vomnibarMatch {
-  color: var(--green);
+  color: var(--vimium-green);
   font-weight: bold;
 }
 
 #vomnibar li .vomnibarTitle .vomnibarMatch {
-  color: var(--blue);
+  color: var(--vimium-blue);
 }
 
 #vomnibar li.vomnibarSelected {
-  background-color: var(--surface0);
+  background-color: var(--vimium-surface0);
 }
 
 div.vimiumHUD {
-  background: var(--base);
+  background: var(--vimium-base);
   border: none;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
 }
 
 div.vimiumHUD span#hud-find-input,
 div.vimiumHUD .vimiumHUDSearchAreaInner {
-  color: var(--text)
+  color: var(--vimium-text)
 }
 
 div.vimiumHUD .hud-find {
-  background-color: var(--base);
+  background-color: var(--vimium-base);
   border: none;
 }
 
 div.vimiumHUD .vimiumHUDSearchArea {
-  background-color: var(--base);
+  background-color: var(--vimium-base);
 }

--- a/src/catppuccin-vimium-base.css
+++ b/src/catppuccin-vimium-base.css
@@ -1,13 +1,13 @@
 #vimiumHintMarkerContainer div.internalVimiumHintMarker, #vimiumHintMarkerContainer div.vimiumHintMarker {
   padding: 3px 4px;
-  background: var(--peach);
+  background: var(--vimium-peach);
   border: 1;
-  border-color: var(--mantle);
+  border-color: var(--vimium-mantle);
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
 }
 
 #vimiumHintMarkerContainer div span {
-  color: var(--mantle);
+  color: var(--vimium-mantle);
   text-shadow: none;
 }
 
@@ -16,12 +16,12 @@
 }
 
 #vimiumHintMarkerContainer div > .matchingCharacter ~ span {
-  color: var(--surface2);
+  color: var(--vimium-surface2);
 }
 
 #vomnibar {
-  background: var(--base);
-  border: 2px solid var(--lavender);
+  background: var(--vimium-base);
+  border: 2px solid var(--vimium-lavender);
   animation: show 200ms cubic-bezier(0, 0, 0.2, 1) forwards;
   max-height: calc(100vh - 70px);
   overflow: hidden;
@@ -39,8 +39,8 @@
 }
 
 #vomnibar input {
-  color: var(--text);
-  background: var(--base);
+  color: var(--vimium-text);
+  background: var(--vimium-base);
   border: none;
   height: unset;
   padding: 16px 30px;
@@ -49,19 +49,19 @@
 #vomnibar .vomnibarSearchArea {
   border: none;
   padding: unset;
-  background: var(--base)
+  background: var(--vimium-base)
 }
 
 #vomnibar ul {
   padding: 0;
   margin: 0;
-  background: var(--base);
-  border-top: 1px solid var(--surface0);
+  background: var(--vimium-base);
+  border-top: 1px solid var(--vimium-surface0);
 }
 
 #vomnibar li {
   padding: 10px;
-  border-bottom: 1px solid var(--surface0)
+  border-bottom: 1px solid var(--vimium-surface0)
 }
 
 #vomnibar li .vomnibarTopHalf,
@@ -70,48 +70,48 @@
 }
 
 #vomnibar li .vomnibarSource {
-  color: var(--peach);
+  color: var(--vimium-peach);
 }
 
 #vomnibar li em,
 #vomnibar li .vomnibarTitle {
-  color: var(--blue);
+  color: var(--vimium-blue);
   font-weight: bold;
 }
 
 #vomnibar li .vomnibarUrl {
-  color: var(--rosewater);
+  color: var(--vimium-rosewater);
 }
 
 #vomnibar li .vomnibarMatch {
-  color: var(--green);
+  color: var(--vimium-green);
   font-weight: bold;
 }
 
 #vomnibar li .vomnibarTitle .vomnibarMatch {
-  color: var(--blue);
+  color: var(--vimium-blue);
 }
 
 #vomnibar li.vomnibarSelected {
-  background-color: var(--surface0);
+  background-color: var(--vimium-surface0);
 }
 
 div.vimiumHUD {
-  background: var(--base);
+  background: var(--vimium-base);
   border: none;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
 }
 
 div.vimiumHUD span#hud-find-input,
 div.vimiumHUD .vimiumHUDSearchAreaInner {
-  color: var(--text)
+  color: var(--vimium-text)
 }
 
 div.vimiumHUD .hud-find {
-  background-color: var(--base);
+  background-color: var(--vimium-base);
   border: none;
 }
 
 div.vimiumHUD .vimiumHUDSearchArea {
-  background-color: var(--base);
+  background-color: var(--vimium-base);
 }

--- a/src/palettes/frappe.css
+++ b/src/palettes/frappe.css
@@ -1,14 +1,14 @@
 /* Frappe palette */
 
 :root {
-  --rosewater: #f2d5cf;
-  --peach: #ef9f76;
-  --blue: #8caaee;
-  --lavender: #babbf1;
-  --green: #a6d189;
-  --text: #c6d0f5;
-  --surface2: #626880;
-  --surface0: #414559;
-  --base: #303446;
-  --mantle: #292c3c;
+  --vimium-rosewater: #f2d5cf;
+  --vimium-peach: #ef9f76;
+  --vimium-blue: #8caaee;
+  --vimium-lavender: #babbf1;
+  --vimium-green: #a6d189;
+  --vimium-text: #c6d0f5;
+  --vimium-surface2: #626880;
+  --vimium-surface0: #414559;
+  --vimium-base: #303446;
+  --vimium-mantle: #292c3c;
 }

--- a/src/palettes/latte.css
+++ b/src/palettes/latte.css
@@ -1,14 +1,14 @@
 /* Latte palette */
 
 :root {
-  --rosewater: #dc8a78;
-  --peach: #fe640b;
-  --green: #40a02b;
-  --blue: #1e66f5;
-  --lavender: #7287fd;
-  --text: #4c4f69;
-  --surface2: #acb0be;
-  --surface0: #ccd0da;
-  --base: #eff1f5;
-  --mantle: #e6e9ef;
+  --vimium-rosewater: #dc8a78;
+  --vimium-peach: #fe640b;
+  --vimium-green: #40a02b;
+  --vimium-blue: #1e66f5;
+  --vimium-lavender: #7287fd;
+  --vimium-text: #4c4f69;
+  --vimium-surface2: #acb0be;
+  --vimium-surface0: #ccd0da;
+  --vimium-base: #eff1f5;
+  --vimium-mantle: #e6e9ef;
 }

--- a/src/palettes/macchiato.css
+++ b/src/palettes/macchiato.css
@@ -1,14 +1,14 @@
 /* Macchiato palette */
 
 :root {
-  --rosewater: #f4dbd6;
-  --peach: #f5a97f;
-  --green: #a6da95;
-  --blue: #8aadf4;
-  --lavender: #b7bdf8;
-  --text: #cad3f5;
-  --surface2: #5b6078;
-  --surface0: #363a4f;
-  --base: #24273a;
-  --mantle: #1e2030;
+  --vimium-rosewater: #f4dbd6;
+  --vimium-peach: #f5a97f;
+  --vimium-green: #a6da95;
+  --vimium-blue: #8aadf4;
+  --vimium-lavender: #b7bdf8;
+  --vimium-text: #cad3f5;
+  --vimium-surface2: #5b6078;
+  --vimium-surface0: #363a4f;
+  --vimium-base: #24273a;
+  --vimium-mantle: #1e2030;
 }

--- a/src/palettes/mocha.css
+++ b/src/palettes/mocha.css
@@ -1,14 +1,14 @@
 /* Mocha palette */
 
 :root {
-  --rosewater: #f5e0dc;
-  --peach: #fab387;
-  --green: #a6e3a1;
-  --blue: #89b4fa;
-  --lavender: #b4befe;
-  --text: #cdd6f4;
-  --surface2: #585b70;
-  --surface0: #313244;
-  --base: #1e1e2e;
-  --mantle: #181825;
+  --vimium-rosewater: #f5e0dc;
+  --vimium-peach: #fab387;
+  --vimium-green: #a6e3a1;
+  --vimium-blue: #89b4fa;
+  --vimium-lavender: #b4befe;
+  --vimium-text: #cdd6f4;
+  --vimium-surface2: #585b70;
+  --vimium-surface0: #313244;
+  --vimium-base: #1e1e2e;
+  --vimium-mantle: #181825;
 }


### PR DESCRIPTION
For the longest time I couldn't figure out why some websites looked strange. Some of the CSS variable names used for this theme are too generic, especially `--text`, which leads to Vimium overwriting the value set in the webpages stylesheet.

This PR namespaces all the variables with `--vimium-` to (hopefully) avoid this situation.
![vimium-leaky-css-vars](https://github.com/catppuccin/vimium/assets/4262486/0a18494e-92fc-4c5d-be2b-ea65975036fa)
