### PR TITLE
feat: style new tab and options page

### DIFF
--- a/themes/catppuccin-vimium-frappe.css
+++ b/themes/catppuccin-vimium-frappe.css
@@ -11,6 +11,7 @@
   --vimium-surface0: #414559;
   --vimium-base: #303446;
   --vimium-mantle: #292c3c;
+  --vimium-mantle: #232634;
 }
 #vimiumHintMarkerContainer div.internalVimiumHintMarker, #vimiumHintMarkerContainer div.vimiumHintMarker {
   padding: 3px 4px;
@@ -126,6 +127,29 @@ div.vimiumHUD .hud-find {
   border: none;
 }
 
-div.vimiumHUD .vimiumHUDSearchArea {
+div.vimiumHUD .vimiumHUDSearchArea, body.vimiumBody {
   background-color: var(--vimium-base);
+}
+
+#footerWrapper, #userDefinedLinkHintCss, #scrollStepSize, #linkHintNumbers, #newTabUrl, #nextPatterns, #previousPatterns, #searchUrl, #linkHintCharacters, #searchEngines, #keyMappings, #u
+ploadBackup
+{
+  background-color: var(--vimium-mantle);
+}
+
+#footer, .remove, input[name="pattern"], input[name="passKeys"], #uploadBackup
+{
+  background-color: var(--vimium-mantle) !important;
+}
+
+body.vimiumBody input {
+  border-color: var(--vimium-crust);
+}
+
+body.vimiumBody a {
+  color: var(--vimium-lavender);
+}
+
+body.vimiumBody .exclusionHeaderText, body.vimiumBody .example, body.vimiumBody .caption, body.vimiumBody header, body.vimiumBody textarea, body.vimiumBody input, body.vimiumBody label  {
+  color: var(--vimium-text) !important;
 }

--- a/themes/catppuccin-vimium-frappe.css
+++ b/themes/catppuccin-vimium-frappe.css
@@ -11,7 +11,7 @@
   --vimium-surface0: #414559;
   --vimium-base: #303446;
   --vimium-mantle: #292c3c;
-  --vimium-mantle: #232634;
+  --vimium-crust: #232634;
 }
 #vimiumHintMarkerContainer div.internalVimiumHintMarker, #vimiumHintMarkerContainer div.vimiumHintMarker {
   padding: 3px 4px;
@@ -127,17 +127,20 @@ div.vimiumHUD .hud-find {
   border: none;
 }
 
-div.vimiumHUD .vimiumHUDSearchArea, body.vimiumBody {
+div.vimiumHUD .vimiumHUDSearchArea {
   background-color: var(--vimium-base);
 }
 
-#footerWrapper, #userDefinedLinkHintCss, #scrollStepSize, #linkHintNumbers, #newTabUrl, #nextPatterns, #previousPatterns, #searchUrl, #linkHintCharacters, #searchEngines, #keyMappings, #u
-ploadBackup
+body.vimiumBody, .vimiumBody {
+  background-color: var(--vimium-base) !important;
+}
+
+.vimiumBody #footerWrapper, #userDefinedLinkHintCss, #scrollStepSize, #linkHintNumbers, #newTabUrl, #nextPatterns, #previousPatterns, #searchUrl, #linkHintCharacters, #searchEngines, #keyMappings, #uploadBackup
 {
   background-color: var(--vimium-mantle);
 }
 
-#footer, .remove, input[name="pattern"], input[name="passKeys"], #uploadBackup
+.vimiumBody #footer, .vimiumBody .remove, input[name="pattern"], input[name="passKeys"], #uploadBackup
 {
   background-color: var(--vimium-mantle) !important;
 }

--- a/themes/catppuccin-vimium-frappe.css
+++ b/themes/catppuccin-vimium-frappe.css
@@ -137,12 +137,14 @@ body.vimiumBody, .vimiumBody {
 
 .vimiumBody #footerWrapper, #userDefinedLinkHintCss, #scrollStepSize, #linkHintNumbers, #newTabUrl, #nextPatterns, #previousPatterns, #searchUrl, #linkHintCharacters, #searchEngines, #keyMappings, #uploadBackup
 {
+  color: var(--vimium-text) !important;
   background-color: var(--vimium-mantle);
 }
 
 .vimiumBody #footer, .vimiumBody .remove, input[name="pattern"], input[name="passKeys"], #uploadBackup
 {
   background-color: var(--vimium-mantle) !important;
+  color: var(--vimium-text) !important;
 }
 
 body.vimiumBody input {

--- a/themes/catppuccin-vimium-latte.css
+++ b/themes/catppuccin-vimium-latte.css
@@ -122,17 +122,25 @@ div.vimiumHUD .vimiumHUDSearchAreaInner {
   color: var(--vimium-text)
 }
 
-div.vimiumHUD .vimiumHUDSearchArea, body.vimiumBody {
+div.vimiumHUD .hud-find {
+  background-color: var(--vimium-base);
+  border: none;
+}
+
+div.vimiumHUD .vimiumHUDSearchArea {
   background-color: var(--vimium-base);
 }
 
-#footerWrapper, #userDefinedLinkHintCss, #scrollStepSize, #linkHintNumbers, #newTabUrl, #nextPatterns, #previousPatterns, #searchUrl, #linkHintCharacters, #searchEngines, #keyMappings, #u
-ploadBackup
+body.vimiumBody, .vimiumBody {
+  background-color: var(--vimium-base) !important;
+}
+
+.vimiumBody #footerWrapper, #userDefinedLinkHintCss, #scrollStepSize, #linkHintNumbers, #newTabUrl, #nextPatterns, #previousPatterns, #searchUrl, #linkHintCharacters, #searchEngines, #keyMappings, #uploadBackup
 {
   background-color: var(--vimium-mantle);
 }
 
-#footer, .remove, input[name="pattern"], input[name="passKeys"], #uploadBackup
+.vimiumBody #footer, .vimiumBody .remove, input[name="pattern"], input[name="passKeys"], #uploadBackup
 {
   background-color: var(--vimium-mantle) !important;
 }
@@ -140,12 +148,6 @@ ploadBackup
 body.vimiumBody input {
   border-color: var(--vimium-crust);
 }
-
-div.vimiumHUD .hud-find {
-  background-color: var(--vimium-base);
-  border: none;
-}
-
 
 body.vimiumBody a {
   color: var(--vimium-lavender);

--- a/themes/catppuccin-vimium-latte.css
+++ b/themes/catppuccin-vimium-latte.css
@@ -11,6 +11,7 @@
   --vimium-surface0: #ccd0da;
   --vimium-base: #eff1f5;
   --vimium-mantle: #e6e9ef;
+  --vimium-crust: #dce0e8;
 }
 #vimiumHintMarkerContainer div.internalVimiumHintMarker, #vimiumHintMarkerContainer div.vimiumHintMarker {
   padding: 3px 4px;
@@ -121,11 +122,35 @@ div.vimiumHUD .vimiumHUDSearchAreaInner {
   color: var(--vimium-text)
 }
 
+div.vimiumHUD .vimiumHUDSearchArea, body.vimiumBody {
+  background-color: var(--vimium-base);
+}
+
+#footerWrapper, #userDefinedLinkHintCss, #scrollStepSize, #linkHintNumbers, #newTabUrl, #nextPatterns, #previousPatterns, #searchUrl, #linkHintCharacters, #searchEngines, #keyMappings, #u
+ploadBackup
+{
+  background-color: var(--vimium-mantle);
+}
+
+#footer, .remove, input[name="pattern"], input[name="passKeys"], #uploadBackup
+{
+  background-color: var(--vimium-mantle) !important;
+}
+
+body.vimiumBody input {
+  border-color: var(--vimium-crust);
+}
+
 div.vimiumHUD .hud-find {
   background-color: var(--vimium-base);
   border: none;
 }
 
-div.vimiumHUD .vimiumHUDSearchArea {
-  background-color: var(--vimium-base);
+
+body.vimiumBody a {
+  color: var(--vimium-lavender);
+}
+
+body.vimiumBody .exclusionHeaderText, body.vimiumBody .example, body.vimiumBody .caption, body.vimiumBody header, body.vimiumBody textarea, body.vimiumBody input, body.vimiumBody label  {
+  color: var(--vimium-text) !important;
 }

--- a/themes/catppuccin-vimium-latte.css
+++ b/themes/catppuccin-vimium-latte.css
@@ -137,12 +137,14 @@ body.vimiumBody, .vimiumBody {
 
 .vimiumBody #footerWrapper, #userDefinedLinkHintCss, #scrollStepSize, #linkHintNumbers, #newTabUrl, #nextPatterns, #previousPatterns, #searchUrl, #linkHintCharacters, #searchEngines, #keyMappings, #uploadBackup
 {
+  color: var(--vimium-text) !important;
   background-color: var(--vimium-mantle);
 }
 
 .vimiumBody #footer, .vimiumBody .remove, input[name="pattern"], input[name="passKeys"], #uploadBackup
 {
   background-color: var(--vimium-mantle) !important;
+  color: var(--vimium-text) !important;
 }
 
 body.vimiumBody input {

--- a/themes/catppuccin-vimium-macchiato.css
+++ b/themes/catppuccin-vimium-macchiato.css
@@ -127,17 +127,20 @@ div.vimiumHUD .hud-find {
   border: none;
 }
 
-div.vimiumHUD .vimiumHUDSearchArea, body.vimiumBody {
+div.vimiumHUD .vimiumHUDSearchArea {
   background-color: var(--vimium-base);
 }
 
-#footerWrapper, #userDefinedLinkHintCss, #scrollStepSize, #linkHintNumbers, #newTabUrl, #nextPatterns, #previousPatterns, #searchUrl, #linkHintCharacters, #searchEngines, #keyMappings, #u
-ploadBackup
+body.vimiumBody, .vimiumBody {
+  background-color: var(--vimium-base) !important;
+}
+
+.vimiumBody #footerWrapper, #userDefinedLinkHintCss, #scrollStepSize, #linkHintNumbers, #newTabUrl, #nextPatterns, #previousPatterns, #searchUrl, #linkHintCharacters, #searchEngines, #keyMappings, #uploadBackup
 {
   background-color: var(--vimium-mantle);
 }
 
-#footer, .remove, input[name="pattern"], input[name="passKeys"], #uploadBackup
+.vimiumBody #footer, .vimiumBody .remove, input[name="pattern"], input[name="passKeys"], #uploadBackup
 {
   background-color: var(--vimium-mantle) !important;
 }

--- a/themes/catppuccin-vimium-macchiato.css
+++ b/themes/catppuccin-vimium-macchiato.css
@@ -11,6 +11,7 @@
   --vimium-surface0: #363a4f;
   --vimium-base: #24273a;
   --vimium-mantle: #1e2030;
+  --vimium-crust: #181926;
 }
 #vimiumHintMarkerContainer div.internalVimiumHintMarker, #vimiumHintMarkerContainer div.vimiumHintMarker {
   padding: 3px 4px;
@@ -126,6 +127,29 @@ div.vimiumHUD .hud-find {
   border: none;
 }
 
-div.vimiumHUD .vimiumHUDSearchArea {
+div.vimiumHUD .vimiumHUDSearchArea, body.vimiumBody {
   background-color: var(--vimium-base);
+}
+
+#footerWrapper, #userDefinedLinkHintCss, #scrollStepSize, #linkHintNumbers, #newTabUrl, #nextPatterns, #previousPatterns, #searchUrl, #linkHintCharacters, #searchEngines, #keyMappings, #u
+ploadBackup
+{
+  background-color: var(--vimium-mantle);
+}
+
+#footer, .remove, input[name="pattern"], input[name="passKeys"], #uploadBackup
+{
+  background-color: var(--vimium-mantle) !important;
+}
+
+body.vimiumBody input {
+  border-color: var(--vimium-crust);
+}
+
+body.vimiumBody a {
+  color: var(--vimium-lavender);
+}
+
+body.vimiumBody .exclusionHeaderText, body.vimiumBody .example, body.vimiumBody .caption, body.vimiumBody header, body.vimiumBody textarea, body.vimiumBody input, body.vimiumBody label  {
+  color: var(--vimium-text) !important;
 }

--- a/themes/catppuccin-vimium-macchiato.css
+++ b/themes/catppuccin-vimium-macchiato.css
@@ -137,12 +137,14 @@ body.vimiumBody, .vimiumBody {
 
 .vimiumBody #footerWrapper, #userDefinedLinkHintCss, #scrollStepSize, #linkHintNumbers, #newTabUrl, #nextPatterns, #previousPatterns, #searchUrl, #linkHintCharacters, #searchEngines, #keyMappings, #uploadBackup
 {
+  color: var(--vimium-text) !important;
   background-color: var(--vimium-mantle);
 }
 
 .vimiumBody #footer, .vimiumBody .remove, input[name="pattern"], input[name="passKeys"], #uploadBackup
 {
   background-color: var(--vimium-mantle) !important;
+  color: var(--vimium-text) !important;
 }
 
 body.vimiumBody input {

--- a/themes/catppuccin-vimium-mocha.css
+++ b/themes/catppuccin-vimium-mocha.css
@@ -127,19 +127,20 @@ div.vimiumHUD .hud-find {
   border: none;
 }
 
-div.vimiumHUD .vimiumHUDSearchArea  {
+div.vimiumHUD .vimiumHUDSearchArea {
   background-color: var(--vimium-base);
 }
 
 body.vimiumBody, .vimiumBody {
   background-color: var(--vimium-base) !important;
 }
-#footerWrapper, #userDefinedLinkHintCss, #scrollStepSize, #linkHintNumbers, #newTabUrl, #nextPatterns, #previousPatterns, #searchUrl, #linkHintCharacters, #searchEngines, #keyMappings, #uploadBackup
+
+.vimiumBody #footerWrapper, #userDefinedLinkHintCss, #scrollStepSize, #linkHintNumbers, #newTabUrl, #nextPatterns, #previousPatterns, #searchUrl, #linkHintCharacters, #searchEngines, #keyMappings, #uploadBackup
 {
   background-color: var(--vimium-mantle);
 }
 
-#footer, .remove, input[name="pattern"], input[name="passKeys"], #uploadBackup
+.vimiumBody #footer, .vimiumBody .remove, input[name="pattern"], input[name="passKeys"], #uploadBackup
 {
   background-color: var(--vimium-mantle) !important;
 }

--- a/themes/catppuccin-vimium-mocha.css
+++ b/themes/catppuccin-vimium-mocha.css
@@ -11,6 +11,7 @@
   --vimium-surface0: #313244;
   --vimium-base: #1e1e2e;
   --vimium-mantle: #181825;
+  --vimium-crust: #11111b;
 }
 #vimiumHintMarkerContainer div.internalVimiumHintMarker, #vimiumHintMarkerContainer div.vimiumHintMarker {
   padding: 3px 4px;
@@ -126,6 +127,31 @@ div.vimiumHUD .hud-find {
   border: none;
 }
 
-div.vimiumHUD .vimiumHUDSearchArea {
+div.vimiumHUD .vimiumHUDSearchArea  {
   background-color: var(--vimium-base);
+}
+
+body.vimiumBody, .vimiumBody {
+  background-color: var(--vimium-base) !important;
+}
+#footerWrapper, #userDefinedLinkHintCss, #scrollStepSize, #linkHintNumbers, #newTabUrl, #nextPatterns, #previousPatterns, #searchUrl, #linkHintCharacters, #searchEngines, #keyMappings, #uploadBackup
+{
+  background-color: var(--vimium-mantle);
+}
+
+#footer, .remove, input[name="pattern"], input[name="passKeys"], #uploadBackup
+{
+  background-color: var(--vimium-mantle) !important;
+}
+
+body.vimiumBody input {
+  border-color: var(--vimium-crust);
+}
+
+body.vimiumBody a {
+  color: var(--vimium-lavender);
+}
+
+body.vimiumBody .exclusionHeaderText, body.vimiumBody .example, body.vimiumBody .caption, body.vimiumBody header, body.vimiumBody textarea, body.vimiumBody input, body.vimiumBody label  {
+  color: var(--vimium-text) !important;
 }

--- a/themes/catppuccin-vimium-mocha.css
+++ b/themes/catppuccin-vimium-mocha.css
@@ -137,12 +137,14 @@ body.vimiumBody, .vimiumBody {
 
 .vimiumBody #footerWrapper, #userDefinedLinkHintCss, #scrollStepSize, #linkHintNumbers, #newTabUrl, #nextPatterns, #previousPatterns, #searchUrl, #linkHintCharacters, #searchEngines, #keyMappings, #uploadBackup
 {
+  color: var(--vimium-text) !important;
   background-color: var(--vimium-mantle);
 }
 
 .vimiumBody #footer, .vimiumBody .remove, input[name="pattern"], input[name="passKeys"], #uploadBackup
 {
   background-color: var(--vimium-mantle) !important;
+  color: var(--vimium-text) !important;
 }
 
 body.vimiumBody input {

--- a/vimium.tera
+++ b/vimium.tera
@@ -145,12 +145,14 @@ body.vimiumBody, .vimiumBody {
 
 .vimiumBody #footerWrapper, #userDefinedLinkHintCss, #scrollStepSize, #linkHintNumbers, #newTabUrl, #nextPatterns, #previousPatterns, #searchUrl, #linkHintCharacters, #searchEngines, #keyMappings, #uploadBackup
 {
+  color: var(--vimium-text) !important;
   background-color: var(--vimium-mantle);
 }
 
 .vimiumBody #footer, .vimiumBody .remove, input[name="pattern"], input[name="passKeys"], #uploadBackup
 {
   background-color: var(--vimium-mantle) !important;
+  color: var(--vimium-text) !important;
 }
 
 body.vimiumBody input {

--- a/vimium.tera
+++ b/vimium.tera
@@ -19,6 +19,7 @@ whiskers:
   --vimium-surface0: {{surface0.hex}};
   --vimium-base: {{base.hex}};
   --vimium-mantle: {{mantle.hex}};
+  --vimium-crust: {{crust.hex}};
 }
 #vimiumHintMarkerContainer div.internalVimiumHintMarker, #vimiumHintMarkerContainer div.vimiumHintMarker {
   padding: 3px 4px;
@@ -136,4 +137,30 @@ div.vimiumHUD .hud-find {
 
 div.vimiumHUD .vimiumHUDSearchArea {
   background-color: var(--vimium-base);
+}
+
+body.vimiumBody, .vimiumBody {
+  background-color: var(--vimium-base) !important;
+}
+
+.vimiumBody #footerWrapper, #userDefinedLinkHintCss, #scrollStepSize, #linkHintNumbers, #newTabUrl, #nextPatterns, #previousPatterns, #searchUrl, #linkHintCharacters, #searchEngines, #keyMappings, #uploadBackup
+{
+  background-color: var(--vimium-mantle);
+}
+
+.vimiumBody #footer, .vimiumBody .remove, input[name="pattern"], input[name="passKeys"], #uploadBackup
+{
+  background-color: var(--vimium-mantle) !important;
+}
+
+body.vimiumBody input {
+  border-color: var(--vimium-crust);
+}
+
+body.vimiumBody a {
+  color: var(--vimium-lavender);
+}
+
+body.vimiumBody .exclusionHeaderText, body.vimiumBody .example, body.vimiumBody .caption, body.vimiumBody header, body.vimiumBody textarea, body.vimiumBody input, body.vimiumBody label  {
+  color: var(--vimium-text) !important;
 }


### PR DESCRIPTION
Heya!
I noticed that when using the ```pages/blank.html``` option when opening a new tab with 't', the blank page uses a default page background, that doesn't match the Catppuccin background colour. I didn't like this as it didn't match the Cattppuccin FireFox theme I am using. I have found that this is possible to change by adding a few lines of CSS to Catppuccin's Vimium theme.

I then decided to go overboard, and themed Vimium's options menu page as well.

I then decided to make this work for all four Catppuccin themes :)

I spent a bit of time trying to get this to work on Chromium based browsers, however it seems like Chromium prevents the CSS from loading - I use FireFox so didn't go crazy trying to find why it didn't work, and this doesn't seem to negatively do anything for Chromium browsers, however it is a nice update for FireFox (and Floorp) IMO :) - that said - if anyone finds a way to fix this, please let me know in the PR, or fork it :)

I have added some images to show the difference before and after (using the Mocha theme):

![FloorpBeforeNewTab](https://github.com/user-attachments/assets/cac39f09-213f-4432-81b3-1ada865556ba)

![FloorpAfterNewTab](https://github.com/user-attachments/assets/66f7c102-60bf-4056-859b-355de5b4aaea)

![FloorpBeforeOptionsPage](https://github.com/user-attachments/assets/f9c9dfbc-e5bb-4914-a53c-2f03f7357039)

![FloorpAfterOptionsPage](https://github.com/user-attachments/assets/32caf897-4bd5-4e7f-899b-a67425fbeacf)

